### PR TITLE
fix SpiderStream build

### DIFF
--- a/SpiderStream/_csharp/SpiderRock.SpiderStream/Mbus/Layouts/DateTimeLayout.cs
+++ b/SpiderStream/_csharp/SpiderRock.SpiderStream/Mbus/Layouts/DateTimeLayout.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -7,7 +8,7 @@ using System.Text;
 namespace SpiderRock.SpiderStream.Mbus.Layouts;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 8)]
-internal struct DateTimeLayout : IEquatable<DateTimeLayout>
+unsafe internal struct DateTimeLayout : IEquatable<DateTimeLayout>
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Equals(DateTimeLayout other) => Ticks == other.Ticks;
@@ -25,7 +26,7 @@ internal struct DateTimeLayout : IEquatable<DateTimeLayout>
 
     private readonly long _data;
 
-    public DateTimeLayout(long data)
+    unsafe public DateTimeLayout(long ticks)
     {
         var dttm = new DateTime(ticks, DateTimeKind.Unspecified);
         _data = *(long*)&dttm;

--- a/SpiderStream/_csharp/SpiderStream.sln
+++ b/SpiderStream/_csharp/SpiderStream.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CmePrintDefChecker", "CmePr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpiderRock.SpiderStream", "SpiderRock.SpiderStream\SpiderRock.SpiderStream.csproj", "{A96908AA-7692-4536-B277-5DEA14B7CB7C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuotePriceSizeTracker", "QuotePriceSizeTracker\QuotePriceSizeTracker.csproj", "{BCAC3D7A-2CFC-4657-B84C-658BAE766ABB}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
there were some typos when porting over the DateTimeLayout from the main repo in #8.  this PR fixes those.  it also addresses a longer standing issue with the main SpiderStream solution file.