### PR TITLE
Update Linux build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+MLink/_c++/.idea/
+MLink/_c++/cmake-build*

--- a/MLink/_c++/CMakeLists.txt
+++ b/MLink/_c++/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.28)
+project(spiderrock_client)
+set(CMAKE_CXX_STANDARD 20)
+
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
+find_package(Boost 1.81.0 COMPONENTS url REQUIRED)
+find_package (Threads REQUIRED)
+find_package(OpenSSL REQUIRED)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/headers/Codec)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/headers/Messages)
+include_directories(${OPENSSL_INCLUDE_DIR})
+
+#build stkprt
+add_executable(stkprt ${CMAKE_CURRENT_SOURCE_DIR}/examples/Linux/StockPrint/StkPrt.cpp)
+target_link_libraries(stkprt PUBLIC
+        ${Boost_LIBRARIES}
+        ${OPENSSL_LIBRARIES}
+        Threads::Threads
+)
+
+#build livesurfaceprt
+add_executable(livesurfaceprt ${CMAKE_CURRENT_SOURCE_DIR}/examples/Linux/LiveSurfaceCurve/livesurfaceprt.cpp)
+target_link_libraries(livesurfaceprt PUBLIC
+        ${Boost_LIBRARIES}
+        ${OPENSSL_LIBRARIES}
+        Threads::Threads
+)
+
+#build LiveImpliedQuoteMultipleStripes
+add_executable(LiveImpliedQuoteMultipleStripes ${CMAKE_CURRENT_SOURCE_DIR}/examples/Linux/LiveImpliedQuote/LiveImpliedQuoteMultipleStripes.cpp)
+target_link_libraries(LiveImpliedQuoteMultipleStripes PUBLIC
+        ${Boost_LIBRARIES}
+        ${OPENSSL_LIBRARIES}
+        Threads::Threads
+)
+

--- a/MLink/_c++/README.md
+++ b/MLink/_c++/README.md
@@ -1,0 +1,25 @@
+# Build instructions (Mac and Linux)
+
+Boost 1.81.0 minimum and OpenSSL is required. 
+
+
+Build all examples under the Linux folder
+
+```
+mkdir build
+cd build
+cmake ..
+cmake --build .
+```
+
+Targeting a specific artifact, for example StockPrint
+
+```
+mkdir build
+cd build
+cmake ..
+cmake --build . --target stkprt
+```
+
+
+


### PR DESCRIPTION
The current provided CMake files under the Linux examples do not work and also warns about Policy CMP0167 not being set. 

This pull request includes a single build file for all examples where the user may select all or a subset of the targets fixing the build error and warning. 

The pull request also includes an gitignore excluding jetbrains CLion projects and artifacts.  

Fixed Warning:
CMake Warning (dev) at CMakeLists.txt:35 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

This warning is for project developers.  Use -Wno-dev to suppress it.

Fixed Error:
cmake --build . 
[ 50%] Building CXX object CMakeFiles/stkprt.dir/stkprt.cpp.o
/Users/anderscedronius/aaa/SpiderRock-Connect-SDK/MLink/_c++/examples/Linux/StockPrint/stkprt.cpp:4:10: fatal error: 'spiderrock_mlink.hpp' file not found
    4 | #include "spiderrock_mlink.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/stkprt.dir/stkprt.cpp.o] Error 1
make[1]: *** [CMakeFiles/stkprt.dir/all] Error 2
make: *** [all] Error 2


