### PR TITLE
SpiderStream updates 20260703: add TXSE

### DIFF
--- a/SpiderStream/_c++/include/SpiderRock/SpiderStream/Enums.Auto.h
+++ b/SpiderStream/_c++/include/SpiderRock/SpiderStream/Enums.Auto.h
@@ -1008,7 +1008,8 @@ namespace SpiderRock
 			NXML=31,
 			NXOS=32,
 			NXP=33,
-			X24=34
+			X24=34,
+			TXSE=36
 		};
 
  		enum class StkPrintType : Enum 

--- a/SpiderStream/_csharp/Benchmark/Benchmark.csproj
+++ b/SpiderStream/_csharp/Benchmark/Benchmark.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>SRBenchmark</RootNamespace>
     <AssemblyName>SRBenchmark</AssemblyName>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SpiderRock.SpiderStream\SpiderRock.SpiderStream.csproj" />

--- a/SpiderStream/_csharp/Benchmark/Benchmark.csproj
+++ b/SpiderStream/_csharp/Benchmark/Benchmark.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>SRBenchmark</RootNamespace>
     <AssemblyName>SRBenchmark</AssemblyName>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SpiderRock.SpiderStream\SpiderRock.SpiderStream.csproj" />

--- a/SpiderStream/_csharp/CmePrintDefChecker/CmePrintDefChecker.csproj
+++ b/SpiderStream/_csharp/CmePrintDefChecker/CmePrintDefChecker.csproj
@@ -4,6 +4,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <OutputType>Exe</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SpiderRock.SpiderStream\SpiderRock.SpiderStream.csproj" />

--- a/SpiderStream/_csharp/CmePrintDefChecker/CmePrintDefChecker.csproj
+++ b/SpiderStream/_csharp/CmePrintDefChecker/CmePrintDefChecker.csproj
@@ -4,7 +4,6 @@
     <PlatformTarget>x64</PlatformTarget>
     <OutputType>Exe</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SpiderRock.SpiderStream\SpiderRock.SpiderStream.csproj" />

--- a/SpiderStream/_csharp/ServerExample/ServerExample.csproj
+++ b/SpiderStream/_csharp/ServerExample/ServerExample.csproj
@@ -4,6 +4,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <OutputType>Exe</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SpiderRock.SpiderStream\SpiderRock.SpiderStream.csproj" />

--- a/SpiderStream/_csharp/ServerExample/ServerExample.csproj
+++ b/SpiderStream/_csharp/ServerExample/ServerExample.csproj
@@ -4,7 +4,6 @@
     <PlatformTarget>x64</PlatformTarget>
     <OutputType>Exe</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SpiderRock.SpiderStream\SpiderRock.SpiderStream.csproj" />

--- a/SpiderStream/_csharp/SpiderRock.SpiderStream/Enums.Auto.cs
+++ b/SpiderStream/_csharp/SpiderRock.SpiderStream/Enums.Auto.cs
@@ -69,7 +69,7 @@ public enum AdjConvention : byte { None=0,Original=1,OSI=2,SpcOnly=3,OSIAlt=4 };
  public enum RunStatus : byte { None=0,Prod=1,Beta=2,UAT=3,SysTest=4 };		
  public enum SpdrKeyType : byte { None=0,Stock=1,Future=2,Option=3,MLeg=4 };		
  public enum SpreadClass : byte { None=0,Stk=1,Fut=2,Call=3,Put=4,Synth=5,RevCon=6,Box=7,JRoll=8,Roll=9,Straddle=10,Strangle=11,CSpread=12,PSpread=13,VStrip=14,VSpread=15,HStrip=16,HSpread=17,BFly=18,RiskRev=19,Mixed=20,VarSwap=21,Pair=22,ExpPair=23,VolPair=24 };		
- public enum StkExch : byte { None=0,AMEX=1,NQBX=2,NSX=3,FNRA=4,ISE=5,EDGA=6,EDGX=7,CHX=8,NYSE=9,ARCA=10,NSDQ=11,CBSX=12,PSX=13,BTSY=14,BATS=15,CBIDX=16,IEX=17,OTC=18,MPRL=19,LTSE=20,MEMX=21,MXIDX=22,DJIDX=23,BXE=24,CXE=25,DXE=26,XETRA=27,NXAM=28,NXBR=29,NXLS=30,NXML=31,NXOS=32,NXP=33,X24=34 };		
+ public enum StkExch : byte { None=0,AMEX=1,NQBX=2,NSX=3,FNRA=4,ISE=5,EDGA=6,EDGX=7,CHX=8,NYSE=9,ARCA=10,NSDQ=11,CBSX=12,PSX=13,BTSY=14,BATS=15,CBIDX=16,IEX=17,OTC=18,MPRL=19,LTSE=20,MEMX=21,MXIDX=22,DJIDX=23,BXE=24,CXE=25,DXE=26,XETRA=27,NXAM=28,NXBR=29,NXLS=30,NXML=31,NXOS=32,NXP=33,X24=34,TXSE=36 };		
  public enum StkPrintType : byte { None=0,RegularSequence=1,OutOfSequence=2,VolumeOnly=3,ExtendedHours=4,OddLot=5,OddLotExtendedHours=6 };		
  public enum StrategyClass : byte { None=0,Single=1,Covered=2,Synthetic=3,Straddle=4,RevCon=5,OptRoll=6,Box=7,Vertical=8,Horizontal=9,Mixed=10 };		
  public enum SurfaceCurveType : byte { None=0,Live=1,PrevDay=2,Interp=3,Close=4,Test=5 };		

--- a/SpiderStream/_csharp/SpiderRock.SpiderStream/Mbus/MessageType.Auto.cs
+++ b/SpiderStream/_csharp/SpiderRock.SpiderStream/Mbus/MessageType.Auto.cs
@@ -162,7 +162,7 @@ public partial struct MessageType
             Type = 3080,
             Name = nameof(OddLotBookQuote),
             IsCore = true,
-            SchemaHash = 0x6ea4efc4b86103f7
+            SchemaHash = 0x126699f83339830b
         };
 
         attributes[3140] = new()
@@ -314,7 +314,7 @@ public partial struct MessageType
             Type = 3000,
             Name = nameof(StockBookQuote),
             IsCore = true,
-            SchemaHash = 0x6ea4efc4b86103f7
+            SchemaHash = 0x126699f83339830b
         };
 
         attributes[3020] = new()
@@ -330,7 +330,7 @@ public partial struct MessageType
             Type = 3035,
             Name = nameof(StockImbalance),
             IsCore = true,
-            SchemaHash = 0x58a45610c6b5b6b8
+            SchemaHash = 0x62dd62c6036f7507
         };
 
         attributes[3040] = new()
@@ -346,7 +346,7 @@ public partial struct MessageType
             Type = 3045,
             Name = nameof(StockPrint),
             IsCore = true,
-            SchemaHash = 0x32e5f711824660e5
+            SchemaHash = 0x3698bf4ca916c701
         };
 
         attributes[3055] = new()
@@ -354,7 +354,7 @@ public partial struct MessageType
             Type = 3055,
             Name = nameof(StockPrintMarkup),
             IsCore = true,
-            SchemaHash = 0x2da35b908111cb66
+            SchemaHash = 0x7b1af9b880ffff5
         };
 
         attributes[2700] = new()

--- a/SpiderStream/_csharp/SpiderRock.SpiderStream/SpiderRock.SpiderStream.csproj
+++ b/SpiderStream/_csharp/SpiderRock.SpiderStream/SpiderRock.SpiderStream.csproj
@@ -8,6 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <WarningLevel>2</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>

--- a/SpiderStream/_csharp/SpiderRock.SpiderStream/SpiderRock.SpiderStream.csproj
+++ b/SpiderStream/_csharp/SpiderRock.SpiderStream/SpiderRock.SpiderStream.csproj
@@ -7,7 +7,6 @@
     <RestorePackages>true</RestorePackages>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <WarningLevel>2</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">


### PR DESCRIPTION
- Adds `TXSE=36` to the `StkExch` enum in both:
  - `SpiderStream/_c++/include/SpiderRock/SpiderStream/Enums.Auto.h`
  - `SpiderStream/_csharp/SpiderRock.SpiderStream/Enums.Auto.cs`

- Updates SpiderStream C# message schema hashes in `MessageType.Auto.cs` for:
  - `OddLotBookQuote`
  - `StockBookQuote`
  - `StockImbalance`
  - `StockPrint`
  - `StockPrintMarkup`
